### PR TITLE
Multi-processing implementation in aggregation

### DIFF
--- a/configs/configuration.yaml
+++ b/configs/configuration.yaml
@@ -1,4 +1,7 @@
 config_name: cytopipe_defaults
+analysis_configs:
+  preprocessing:
+    threads: 4
 config_paths:
   single_cell: "configs/analysis_configs/single_cell_configs.yaml"
   annotate: "configs/analysis_configs/annotate_configs.yaml"

--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -42,7 +42,7 @@ rule aggregate:
         "../envs/cytominer_env.yaml"
     params:
         aggregate_config=config["config_paths"]["single_cell"],
-    threads: 6
+    threads: config["analysis_configs"]["preprocessing"]["threads"]
     script:
         "../scripts/aggregate_cells.py"
 

--- a/scripts/aggregate_cells.py
+++ b/scripts/aggregate_cells.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     n_cores = int(snakemake.threads)
     if n_cores > len(inputs):
         print(
-            f"WARNING: number of specify cores exceeds number of inputs, defaulting to {len(inputs)}"
+            f"WARNING: number of specified cores ({n_cores}) exceeds number of inputs ({len(inputs)}), defaulting to {len(inputs)}"
         )
         n_cores = len(inputs)
 

--- a/scripts/aggregate_cells.py
+++ b/scripts/aggregate_cells.py
@@ -17,14 +17,14 @@ def aggregate(
 ):
     """aggregates single cell data into aggregate profiles
 
-    Paramters:
+    Parameters:
     ----------
     sql_file: str
             SQL file that contains single cell data obtain from a single plate
     metadata_dir : str
         associated metadata file with the single cell data
     barcode_path : str
-        file containing the barcode id of each platedata
+        file containing the barcode id of each plate data
     aggregate_file_out : str
         output file generated for aggregate profiles
     cell_count_out: str
@@ -38,7 +38,7 @@ def aggregate(
         Generates cell counts and aggregate profile output
     """
 
-    # loading paramters
+    # loading parameters
     aggregate_path_obj = Path(config)
     aggregate_config_path = aggregate_path_obj.absolute()
     with open(aggregate_config_path, "r") as yaml_contents:

--- a/scripts/aggregate_cells.py
+++ b/scripts/aggregate_cells.py
@@ -115,6 +115,7 @@ if __name__ == "__main__":
         )
         n_cores = len(inputs)
 
+    # Initiate the multi-threading procedure
     with mp.Pool(processes=n_cores) as pool:
         pool.starmap(aggregate, inputs)
         pool.close()

--- a/scripts/consensus.py
+++ b/scripts/consensus.py
@@ -1,8 +1,5 @@
-import numpy as np
 import pandas as pd
 
-from pycytominer.consensus import modz
-from pycytominer import aggregate
 from pycytominer.operations import get_na_columns
 
 

--- a/scripts/feature_select.py
+++ b/scripts/feature_select.py
@@ -60,7 +60,6 @@ if __name__ == "__main__":
 
     # iteratively passing normalized data
     for norm_data, feature_file_out in io_files:
-        print(norm_data, feature_file_out)
         feature_selection(
             normalized_profile=norm_data, out_file=feature_file_out, config=config_path
         )

--- a/scripts/feature_select.py
+++ b/scripts/feature_select.py
@@ -21,7 +21,7 @@ def feature_selection(normalized_profile: str, out_file: str, config: str) -> No
     Generates output
     """
 
-    # loading paramters
+    # loading parameters
     feature_select_ep = Path(config)
     feature_select_config_path = feature_select_ep.absolute()
     with open(feature_select_config_path, "r") as yaml_contents:


### PR DESCRIPTION
## Motivation

Currently it takes around 110 minutes to aggregate all 9 SQLite single-cell plate data (130.07 GB) into aggregated . However, we can improve the computational time if we split the job to multiple cores 

This PR demonstrate multi-processing support in the `aggregate_cells.py` in order to improve computational performance.

## Approach

Changes were applied to the `aggregate_cells.py` and `preprocess.smk` under the `aggregate` rule. Since this step is an iterative process, we can assign each input to an individual core to conduct the aggregation process.

However, this requires some tweaks on how the parameters should be passed in order to conduct multi-processing

```python
# transforming snakemake objects into python standard datatypes
sqlfiles = [str(sqlfile) for sqlfile in snakemake.input["sql_files"]]
cell_count_out = [str(out_name) for out_name in snakemake.output["cell_counts"]]
aggregate_profile_out = [
    str(out_name) for out_name in snakemake.output["aggregate_profile"]
]
meta_data_dir = itertools.repeat(str(snakemake.input["metadata"]))
barcode_map = itertools.repeat(str(snakemake.input["barcodes"]))
config_path = itertools.repeat(str(snakemake.params["aggregate_config"]))
inputs = list(
    zip(sqlfiles, meta_data_dir, barcode_map, cell_count_out, aggregate_profile_out, config_path)
)

# init multi process
n_cores = int(snakemake.threads)
if n_cores > len(inputs):
    print(
        f"WARNING: number of specify cores exceeds number of inputs, defaulting to {len(inputs)}"
    )
    n_cores = len(inputs)

with mp.Pool(processes=n_cores) as pool:
    pool.starmap(aggregate, inputs)
    pool.close()
    pool.join()
```

- `sqlfiles` `cell_count_out` `aggregate_profile_out` `meta_data_dir` `barcode_map` are inputs obtained from `snakemake`
    - the `itertools.repeat` is essential for the `zip` function in order to generate static inputs
        - without it, then single characters will be produced inside the `inputs` list
    - `pool` is instantiating the number of cores based on `snakemake.threads` rule parameter
    - The `pool.starmap` takes in the function name and the inputs iterator and spreads it to the assign cores.
       -  `pool.close()` and `pool.join()` are required to indicate all jobs are complete and close the multi-process scheduler. 

The `aggregate` rule will use the `threads` rule attribute as a parameter for specifying the number of cores to use in the aggregate process 

```python
# preprocess.smk
rule aggregate:
    input:
        sql_files=expand("data/{plate_id}.sqlite", plate_id=PLATE_IDS),
        barcodes="data/barcode_platemap.csv",
        metadata="data/metadata",
    output:
        cell_counts=expand(
            "results/preprocessing/{plate_id}_cell_counts.tsv", plate_id=PLATE_IDS
        ),
        aggregate_profile=expand(
            "results/preprocessing/{plate_id}_aggregate.csv.gz", plate_id=PLATE_IDS
        ),
    conda:
        "../envs/cytominer_env.yaml"
    params:
        aggregate_config=config["config_paths"]["single_cell"],
    threads: config["analysis_configs"]["preprocessing"]["threads"]
    script:
        "../scripts/aggregate_cells.py"
```

Looking at the `threads` rule attribute, the number of threads specified is in the `CytoPipe's` general config file:
```python
# configuration.yaml
config_name: cytopipe_defaults
analysis_configs:
  preprocessing:
    threads: 4
config_paths:
  single_cell: "configs/analysis_configs/single_cell_configs.yaml"
  annotate: "configs/analysis_configs/annotate_configs.yaml"
  normalize: "configs/analysis_configs/normalize_configs.yaml"
  feature_select: "configs/analysis_configs/feature_select_configs.yaml"
  aggregate: "configs/analysis_configs/aggregate_configs.yaml"
```
allowing for user to easily access and change the number of threads used under the preprocessing step.  (NOTE: multi processing is only implemented in the `aggregate` rule and not the following subsequent rules. 

## Implementation Diagram

Below is a simple diagram on how the multi-processing was implemented. 

![mp_diagram](https://user-images.githubusercontent.com/31600622/168904826-68f683e4-aa14-4ac6-8cbb-d6bf60d0dc2d.png)

Simple demonstration of the multi processing diagram. The array above is the set of input parameters required for a function. Then the multi processing module will reserve memory for the parameters and execute it through a CPU. Each CPU will run the aggregate step independently until the parameters list is finished

## Performance Results
To find the optimal number of cores for aggregation, multiple tests were conducted, where each test has an increase of 2 cores for computation. The time was calculated by using the `time` command in the terminal:
`time snakemake -c 10 --use-conda -r aggregate`

![performance_chart](https://user-images.githubusercontent.com/31600622/168905371-b7a29897-ab8b-4b72-808c-c7de2b67e485.png)
![perfromance_plot](https://user-images.githubusercontent.com/31600622/168905378-254f89f9-0c65-43c2-b7b0-4baa7e41c323.png)


The multi-processing implementation does increase aggregation performance, however there is still a major caveat. The largest file will be bottleneck the performance.

In order for the aggregate function to be considered “complete” all cores needs to be finished. This raises and issues with larger files as it will take the most amount of time to finish the processes; therefore, it must wait for that specific processes to finish. [really good explanation here](https://stackoverflow.com/a/26521507)

Unfortunately, this is an I/O bound related issue, which means that your computer spends a lot of time reading from the hard disk before conducting any processes. In addition, I/O bound processes is a bottleneck feature as transferring data from the HDD to the RAM is very slow.
